### PR TITLE
Fixed a bug for creating the Iterators with additional params.

### DIFF
--- a/webdriver-framework-testng/src/main/java/com/browserstack/webdriver/testng/LazyInitWebDriverIterator.java
+++ b/webdriver-framework-testng/src/main/java/com/browserstack/webdriver/testng/LazyInitWebDriverIterator.java
@@ -48,7 +48,7 @@ public class LazyInitWebDriverIterator implements Iterator<Object[]> {
         int idx = 0;
         List<Object[]> tempTestParams = new ArrayList<>();
         do {
-            Object[] testParam = testParams.get(0);
+            Object[] testParam = testParams.get(idx);
             if (testParam == null) {
                 testParam = new Object[0];
             }


### PR DESCRIPTION
When using the TestNG Iterator as below, 

```java    
    @DataProvider(name = "login_error_messages")
    public Iterator<Object[]> data(Method testMethod) {
        List<Object[]> loginErrorMessages = new ArrayList<Object[]>() {{
            add(new Object[]{"locked_user", "testingisfun99", "Your account has been locked."});
            add(new Object[]{"fav_user", "wrongpass", "Invalid Password"});
            add(new Object[]{"helloworld", "testingisfun99", "Invalid Username"});
        }};

        LazyInitWebDriverIterator lazyInitWebDriverIterator = new LazyInitWebDriverIterator(testMethod.getName(),
                                                                                            WebDriverFactory.getInstance().getPlatforms(),
                                                                                            loginErrorMessages);
        return lazyInitWebDriverIterator;
    }
```

The LazyInitWebDriverIterator considers only the first set of additional params and not any of the others. This PR is to fix that issue.